### PR TITLE
Not repeat touched point

### DIFF
--- a/FaulandCc.XF.GesturePatternView/GesturePatternView.cs
+++ b/FaulandCc.XF.GesturePatternView/GesturePatternView.cs
@@ -257,7 +257,8 @@ namespace FaulandCc.XF.GesturePatternView
                 bool hasPendingPoint = true;
                 foreach (var gestureTouchPoint in _touchPoints)
                 {
-                    if (TouchedTouchPoint(location, gestureTouchPoint) && gestureTouchPoint.Value != _lastTouchPointValue)
+                    if (TouchedTouchPoint(location, gestureTouchPoint) && gestureTouchPoint.Value != _lastTouchPointValue && 
+                        !_gestureValueBuilder.ToString().Contains(gestureTouchPoint.Value))
                     {
                         gestureTouchPoint.Touch();
                         _gestureValueBuilder.Append(gestureTouchPoint.Value);


### PR DESCRIPTION
Correction to avoid that the points can be repeated. For example it should not be possible to make a pattern 121212